### PR TITLE
feat(nx-cloudflare-wrangler): add pages serve executor

### DIFF
--- a/packages/nx-cloudflare-wrangler/executors.json
+++ b/packages/nx-cloudflare-wrangler/executors.json
@@ -13,6 +13,10 @@
       "implementation": "./src/executors/workers/build/executor",
       "schema": "./src/executors/workers/build/schema.json"
     },
+    "serve-page": {
+      "implementation": "./src/executors/pages/serve/executor",
+      "schema": "./src/executors/pages/serve/schema.json"
+    },
     "deploy-page": {
       "implementation": "./src/executors/pages/deploy/executor",
       "schema": "./src/executors/pages/deploy/schema.json"

--- a/packages/nx-cloudflare-wrangler/src/executors/pages/serve/executor.ts
+++ b/packages/nx-cloudflare-wrangler/src/executors/pages/serve/executor.ts
@@ -1,0 +1,21 @@
+import { ExecutorContext, joinPathFragments } from '@nrwl/devkit';
+import { PagesServeExecutorSchema } from './schema';
+import { runWranglerCommandForProject } from '../../wrangler';
+
+export default async function deployExecutor(
+    options: PagesServeExecutorSchema,
+    context: ExecutorContext
+) {
+    const dist = joinPathFragments(
+        process.cwd(),
+        context.workspace.projects[context.projectName].targets.build.options
+            .outputPath
+    );
+
+    const deployOptions = {
+        dist,
+        ...options,
+    };
+
+    return runWranglerCommandForProject(deployOptions, context, 'pages dev');
+}

--- a/packages/nx-cloudflare-wrangler/src/executors/pages/serve/schema.d.ts
+++ b/packages/nx-cloudflare-wrangler/src/executors/pages/serve/schema.d.ts
@@ -1,0 +1,1 @@
+export interface PagesServeExecutorSchema {}

--- a/packages/nx-cloudflare-wrangler/src/executors/pages/serve/schema.json
+++ b/packages/nx-cloudflare-wrangler/src/executors/pages/serve/schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "title": "Pages serve executor",
+  "type": "object",
+  "properties": {
+    "dist": {
+      "type": "string",
+      "description": "Location of the build output to serve"
+    }
+  },
+  "required": []
+}

--- a/packages/nx-cloudflare-wrangler/src/executors/wrangler.ts
+++ b/packages/nx-cloudflare-wrangler/src/executors/wrangler.ts
@@ -16,10 +16,9 @@ export function runWranglerCommandForProject(
         | WorkerDeployExecutorSchema
         | PagesDeployExecutorSchema,
     context: ExecutorContext,
-    command: 'dev' | 'publish' | 'pages publish'
+    command: 'dev' | 'publish' | 'pages publish' | 'pages dev'
 ) {
     const { projectName, target } = context;
-    const executorOptions = target.options ?? {};
 
     const tree = new FsTree(process.cwd(), false);
     const projectConfiguration = readProjectConfiguration(tree, projectName);
@@ -51,6 +50,8 @@ export function runWranglerCommandForProject(
                     ? 'true'
                     : 'false')
         );
+    } else if (command === 'pages dev') {
+        wranglerOptions.push((options as PagesDeployExecutorSchema).dist);
     } else if (command === 'publish') {
         wranglerOptions.push(
             joinPathFragments(
@@ -70,8 +71,8 @@ export function runWranglerCommandForProject(
 
     return new Promise((resolve) => {
         try {
-            console.log(`wrangler ${command} ${wranglerOptions.join(' ')}`);
-            execSync(`wrangler ${command} ${wranglerOptions.join(' ')}`, {
+            console.log(`npx wrangler ${command} ${wranglerOptions.join(' ')}`);
+            execSync(`npx wrangler ${command} ${wranglerOptions.join(' ')}`, {
                 cwd: projectConfiguration.root,
                 stdio: 'inherit',
             });


### PR DESCRIPTION
Adding an executor to serve pages. 

Also fixed the `wrangler` command to be executed through `npx` to not require the global wrangler installation to be present.