### PR TITLE
fix(nx-cloudflare-wrangler): custom dist path should be relative to project root

### DIFF
--- a/packages/nx-cloudflare-wrangler/src/executors/pages/deploy/executor.ts
+++ b/packages/nx-cloudflare-wrangler/src/executors/pages/deploy/executor.ts
@@ -2,11 +2,15 @@ import { ExecutorContext, joinPathFragments } from '@nrwl/devkit';
 import { PagesDeployExecutorSchema } from './schema';
 import { runWranglerCommandForProject } from '../../wrangler';
 import { execSync } from 'child_process';
+import { resolve } from 'path';
 
 export default async function deployExecutor(
     options: PagesDeployExecutorSchema,
     context: ExecutorContext
 ) {
+    if (options.dist) {
+        options.dist = resolve(process.cwd(), options.dist);
+    }
     const dist = joinPathFragments(
         process.cwd(),
         context.workspace.projects[context.projectName].targets.build.options

--- a/packages/nx-cloudflare-wrangler/src/executors/pages/serve/executor.ts
+++ b/packages/nx-cloudflare-wrangler/src/executors/pages/serve/executor.ts
@@ -1,11 +1,15 @@
 import { ExecutorContext, joinPathFragments } from '@nrwl/devkit';
 import { PagesServeExecutorSchema } from './schema';
 import { runWranglerCommandForProject } from '../../wrangler';
+import { resolve } from 'path';
 
 export default async function deployExecutor(
     options: PagesServeExecutorSchema,
     context: ExecutorContext
 ) {
+    if (options.dist) {
+        options.dist = resolve(process.cwd(), options.dist);
+    }
     const dist = joinPathFragments(
         process.cwd(),
         context.workspace.projects[context.projectName].targets.build.options

--- a/packages/nx-cloudflare-wrangler/src/executors/pages/serve/schema.d.ts
+++ b/packages/nx-cloudflare-wrangler/src/executors/pages/serve/schema.d.ts
@@ -1,1 +1,3 @@
-export interface PagesServeExecutorSchema {}
+export interface PagesServeExecutorSchema {
+    dist?: string;
+}


### PR DESCRIPTION
Custom dist path in the config is provided to the wrangler CLI as-is, which is wrong, because wrangler operates on the project level, not root.

For example:
```json
    "deploy": {
      "executor": "@k11r/nx-cloudflare-wrangler:deploy-page",
      "options": {
        "dist": "dist/apps/myapp/other-path"
      }
    },
```
will be treated by wrangler as `<workspaceRoot>/apps/myapp/dist/apps/myapp/other-path`

Thus it's now required to provide path as `../../dist/apps/myapp/other-path`, which seems to be incorrect from an Nx configuration standpoint.

**Breaking change:** `options.dist` in "serve-page" and "deploy-page" executors are now relative to workspace root