### PR TITLE
Use deploy instead of publish

### DIFF
--- a/packages/nx-cloudflare-wrangler/src/executors/pages/deploy/executor.ts
+++ b/packages/nx-cloudflare-wrangler/src/executors/pages/deploy/executor.ts
@@ -34,6 +34,6 @@ export default async function deployExecutor(
     return runWranglerCommandForProject(
         deployOptions,
         context,
-        'pages publish'
+        'pages deploy'
     );
 }

--- a/packages/nx-cloudflare-wrangler/src/executors/workers/deploy/executor.ts
+++ b/packages/nx-cloudflare-wrangler/src/executors/workers/deploy/executor.ts
@@ -6,5 +6,5 @@ export default async function deployExecutor(
     options: WorkerDeployExecutorSchema,
     context: ExecutorContext
 ) {
-    return runWranglerCommandForProject(options, context, 'publish');
+    return runWranglerCommandForProject(options, context, 'deploy');
 }

--- a/packages/nx-cloudflare-wrangler/src/executors/wrangler.ts
+++ b/packages/nx-cloudflare-wrangler/src/executors/wrangler.ts
@@ -25,7 +25,7 @@ export function runWranglerCommandForProject(
 
     const wranglerOptions = [];
 
-    if (command === 'pages publish') {
+    if (command === 'pages deploy') {
         wranglerOptions.push((options as PagesDeployExecutorSchema).dist);
         wranglerOptions.push(
             '--project-name="' +
@@ -52,7 +52,7 @@ export function runWranglerCommandForProject(
         );
     } else if (command === 'pages dev') {
         wranglerOptions.push((options as PagesDeployExecutorSchema).dist);
-    } else if (command === 'publish') {
+    } else if (command === 'deploy') {
         wranglerOptions.push(
             joinPathFragments(
                 workspaceRoot,


### PR DESCRIPTION
The package keeps giving a deprecation warning about the publish command.

I've been using this with `patch-package` at work and it's working fine.

Fixes #8 